### PR TITLE
chore: patch cli commands/flags docs disparencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,12 +588,12 @@ HyperBEAM OS provides a command-line interface for all operations:
 #### **VM Management Commands**
 - **`start`** - Start the VM with the current configuration
   ```bash
-  ./run start [--data-disk PATH]
+  ./run start [--data-disk PATH] [--enableSSL]
   ```
 
 - **`start_release`** - Start the VM using packaged release files
   ```bash
-  ./run start_release [--data-disk PATH]
+  ./run start_release [--data-disk PATH] [--enableSSL]
   ```
 
 - **`ssh`** - Connect to the running VM via SSH

--- a/src/cli/cli_handler.py
+++ b/src/cli/cli_handler.py
@@ -31,6 +31,7 @@ COMMANDS:
     Options:
       --snp-release PATH     Use pre-built SNP release directory or tarball (optional)
   setup_host          Set up the host system using the SNP release installer
+  setup_gpu           Setup the GPU CC for the host system
   build_snp_release   Build SNP release package (kernel, OVMF, QEMU) from source
   build_base          Build the base VM image (unpack kernel, build initramfs, create VM)
   


### PR DESCRIPTION
## About

i was playing around with hb-os and found some missing documentation in the cli_parser helper command and the README's cli commands flags (the latest feature's `enableSSL`) 

my git commit is signed 